### PR TITLE
Bugfix split keys in File Class

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -21,7 +21,7 @@ function File(opt, storage) {
 
     if (opt.k) {
       var parts = opt.k.split(':')
-      this.key = crypto.formatKey(parts[1])
+      this.key = crypto.formatKey(parts[parts.length-1])
       storage.aes.decryptKey(this.key)
       this.size = opt.s || 0
       if (opt.a) this._setAttributes(opt.a)


### PR DESCRIPTION
I have tried using the library with my mega account but I had a bug in the init step invoking the mega function (with autoload option to true).
I solved the problem changing in file.js:File the param to crypto.formatKey.

This is the error output:
assert.js:102
  throw new assert.AssertionError({
        ^
AssertionError: Trying to read beyond buffer length
    at readInt32 (buffer.js:777:12)
    at Buffer.readInt32BE (buffer.js:795:10)
    at AES.decryptKey (/Users/fabiux/Documents/mega_example_js/node_modules/mega/lib/crypto/index.js:109:16)
    at new File (/Users/fabiux/Documents/mega_example_js/node_modules/mega/lib/file.js:25:19)
    at Storage._importFile (/Users/fabiux/Documents/mega_example_js/node_modules/mega/lib/storage.js:222:32)
    at Array.forEach (native)
    at Storage.reload.api.on.deleted (/Users/fabiux/Documents/mega_example_js/node_modules/mega/lib/storage.js:168:16)
    at Request.API.request [as _callback](/Users/fabiux/Documents/mega_example_js/node_modules/mega/lib/api.js:72:5)
    at Request.init.self.callback (/Users/fabiux/Documents/mega_example_js/node_modules/mega/node_modules/request/main.js:122:22)
    at Request.EventEmitter.emit (events.js:96:17)
    at Request.<anonymous> (/Users/fabiux/Documents/mega_example_js/node_modules/mega/node_modules/request/main.js:661:16)
